### PR TITLE
fix: Idempotent start

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ You add the ViewModel as a property wrapper to your view:
 @ViewModel var model: AnyReactor = MyViewModel().eraseToAnyReactor()
 ```
 
+`AnyReactor` does not start the wrapped reactor automatically. Start it explicitly:
+
+```swift
+.task { model.start() }
+```
+
 To access the current `State` you use:
 
 ```swift
@@ -200,4 +206,3 @@ You can easily mock state for Xcode Previews by using `Stub` reactor implementat
 
 # License
 GoodReactor repository is released under the MIT license. See [LICENSE](LICENSE.md) for details.
-

--- a/Sources/GoodReactor/Core/Erased/AnyReactor.swift
+++ b/Sources/GoodReactor/Core/Erased/AnyReactor.swift
@@ -25,7 +25,8 @@ import SwiftUI
 ///
 /// Behavior:
 /// - State is accessed dynamically and mutated by reducing events on a concrete underlying reactor.
-/// - Lifecycle: external subscriptions start automatically when `AnyReactor` is initialized (by `start()`-ing the base reactor).
+/// - Lifecycle: `AnyReactor` does not automatically start the wrapped reactor.
+///   Call `start()` explicitly to initialize external subscriptions.
 /// - Events from `send(action:)`, `send(action:) async`, and `send(destination:)` are forwarded to the base reactor.
 ///
 /// Example:
@@ -58,9 +59,11 @@ import SwiftUI
 
     // MARK: - Initialization
 
+    /// Creates a type-erased wrapper around `base`.
+    ///
+    /// - note: This initializer does not call `start()` on `base`.
     public init<R: Reactor>(_ base: R) where R.Action == Action, R.Destination == Destination, R.State == State {
         self._box = AnyReactorBox(base)
-        base.start()
     }
 
 }
@@ -151,4 +154,3 @@ public extension Reactor {
     }
 
 }
-

--- a/Sources/GoodReactor/Core/Reactor.swift
+++ b/Sources/GoodReactor/Core/Reactor.swift
@@ -155,6 +155,9 @@ import SwiftUI
     /// of the reactor.
     ///
     /// You can use multiple subscriptions to multiple external events.
+    ///
+    /// - important: Keep this function free of side effects, except calls to
+    /// ``subscribe(to:map:)``. This function may be invoked multiple times.
     func transform()
 
     #if canImport(Combine)
@@ -329,6 +332,11 @@ public extension Reactor {
     /// uses Combine, subscribes the event stream and publishes the
     /// initial state.
     func start() {
+        let hasSubscriptions = MapTables.subscriptions.value(forKey: self)?.isEmpty == false
+        guard !hasSubscriptions else {
+            return
+        }
+
         self.transform()
 
         #if canImport(Combine)

--- a/Tests/GoodReactorTests/AnyReactorTests.swift
+++ b/Tests/GoodReactorTests/AnyReactorTests.swift
@@ -143,4 +143,28 @@ final class AnyReactorTests: XCTestCase {
         XCTAssertEqual(model.counter, binding.wrappedValue)
     }
 
+    @MainActor func testReactorStartIdempontency() async {
+        let model = AnyReactor(ObservableModel())
+
+        XCTAssertEqual(model.manualEventsCount, 0)
+
+        model.start()
+
+        try? await Task.sleep(for: .milliseconds(100)) // subscriptions start asynchronously
+        await ManualEventPublisher.shared.eventPublisher.send(1)
+        try? await Task.sleep(for: .milliseconds(100)) // events are sent asynchronously
+
+        XCTAssertEqual(model.manualEventsCount, 1)
+
+        model.start()
+        model.start()
+        model.start()
+
+        try? await Task.sleep(for: .milliseconds(100)) // subscriptions start asynchronously
+        await ManualEventPublisher.shared.eventPublisher.send(1)
+        try? await Task.sleep(for: .milliseconds(100)) // events are sent asynchronously
+
+        XCTAssertEqual(model.manualEventsCount, 2)
+    }
+
 }

--- a/Tests/GoodReactorTests/GoodReactorTests.swift
+++ b/Tests/GoodReactorTests/GoodReactorTests.swift
@@ -140,4 +140,28 @@ final class GoodReactorTests: XCTestCase {
         XCTAssertEqual(binding.wrappedValue, 21)
     }
 
+    @MainActor func testReactorStartIdempontency() async {
+        let model = ObservableModel()
+
+        XCTAssertEqual(model.manualEventsCount, 0)
+
+        model.start()
+        
+        try? await Task.sleep(for: .milliseconds(100)) // subscriptions start asynchronously
+        await ManualEventPublisher.shared.eventPublisher.send(1)
+        try? await Task.sleep(for: .milliseconds(100)) // events are sent asynchronously
+
+        XCTAssertEqual(model.manualEventsCount, 1)
+
+        model.start()
+        model.start()
+        model.start()
+
+        try? await Task.sleep(for: .milliseconds(100)) // subscriptions start asynchronously
+        await ManualEventPublisher.shared.eventPublisher.send(1)
+        try? await Task.sleep(for: .milliseconds(100)) // events are sent asynchronously
+
+        XCTAssertEqual(model.manualEventsCount, 2)
+    }
+
 }

--- a/Tests/GoodReactorTests/Samples/ManualEventPublisher.swift
+++ b/Tests/GoodReactorTests/Samples/ManualEventPublisher.swift
@@ -1,0 +1,16 @@
+//
+//  ManualEventPublisher.swift
+//  GoodReactor
+//
+//  Created by te075262 on 01/07/2026.
+//
+
+import Foundation
+import GoodReactor
+
+final class ManualEventPublisher: @unchecked Sendable {
+
+    @MainActor static let shared = ManualEventPublisher()
+    let eventPublisher = GoodReactor.PassthroughPublisher<Int>()
+
+}

--- a/Tests/GoodReactorTests/Samples/ObservableModel.swift
+++ b/Tests/GoodReactorTests/Samples/ObservableModel.swift
@@ -21,6 +21,12 @@ final class EmptyObject {}
         } map: {
             Mutation.didChangeTime(seconds: $0)
         }
+
+        subscribe {
+            await ManualEventPublisher.shared.eventPublisher
+        } map: {
+            Mutation.didReceiveManualEvent(value: $0)
+        }
     }
 
     typealias Event = GoodReactor.Event<Action, Mutation, Destination>
@@ -45,6 +51,7 @@ final class EmptyObject {}
         case didReceiveValue(newValue: Int)
         case didAddOneWithDelay
         case doOneHalfOfTwoHundredRuns
+        case didReceiveManualEvent(value: Int)
     }
 
     // MARK: Destination
@@ -60,6 +67,7 @@ final class EmptyObject {}
         var counter: Int = 9
         var time: Int = 0
         var object: AnyObject = EmptyObject()
+        var manualEventsCount: Int = 0
 
     }
 
@@ -158,6 +166,9 @@ final class EmptyObject {}
 
         case .mutation(.didChangeTime(let seconds)):
             state.time = seconds
+
+        case .mutation(.didReceiveManualEvent(let value)):
+            state.manualEventsCount += value
 
         case .destination:
             break


### PR DESCRIPTION
Added check whether any subscriptions for current Reactor are active. This makes `start` function idempotent for callers, and effectively prevents creating duplicate subscriptions.

Condition: `transform` function must be free of side effects, as empty `transform` will be called multiple times, until first subscription is created for the Reactor.

---

Disabled auto-start of AnyReactor type-erased type.
Previously this auto-start behaviour caused incorrectly stored Combine/non-combine subscriptions to external events from viewModels. Subscriptions were being stored under the wrapper type, which caused confusion and non-clear event routing.

Added tests to verify.

---
### Effects:
Call to `viewModel.start()` now has to be explicit and will always be forwarded to correct concrete Reactor type.